### PR TITLE
Fix for VIDLA-3679

### DIFF
--- a/src/VastManager.js
+++ b/src/VastManager.js
@@ -414,6 +414,7 @@ var vastManager = function () {
 								traceMessage({data: {message: 'Video main content - activate play button'}});
 								_player.bigPlayButton.el_.style.display = 'block';
 								_player.bigPlayButton.el_.style.opacity = 1;
+								_player.bigPlayButton.el_.style.zIndex = 99999;
 								_player.bigPlayButton.one('click', function() {
 									showCover(true);
 								});


### PR DESCRIPTION
Issue: PC Edge browser - Play button is not activated and player shows black screen when dfp is enabled).
Play button is active but covered by black div.