### PR TITLE
VIDLA-3480 - Removed JS that applied in-line CSS to ad markers

### DIFF
--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -34,11 +34,6 @@ var markersHandler = function (vjs) {
 
 	// default setting
 	var defaultSetting = {
-		markerStyle: {
-			'width': '7px',
-			'border-radius': '30%',
-			'background-color': 'red'
-		},
 		markerTip: {
 			display: true,
 			text: function text(marker) {
@@ -128,9 +123,6 @@ var markersHandler = function (vjs) {
 	        'data-marker-time': setting.markerTip.time(marker)
 	      });
 
-	      Object.keys(setting.markerStyle).forEach(function (key) {
-	        markerDiv.style[key] = setting.markerStyle[key];
-	      });
 	      var pos = getPosition(marker);
 	      if (pos === 100) {
 	    	  pos = 99.5;

--- a/src/VastManager.js
+++ b/src/VastManager.js
@@ -501,11 +501,6 @@ var vastManager = function () {
 		if (_options.timeOffset) {
 	        // prepare timeline marker for the ad
 		    var timeMarkers = {
-				markerStyle: {
-					'width': '5px',
-					'border-radius': '10%',
-					'background-color': 'white'
-				},
 				markerTip: {
 					display: false
 				},

--- a/src/bc_prebid_vast_vjs.css
+++ b/src/bc_prebid_vast_vjs.css
@@ -9,6 +9,9 @@
   -webkit-transition: opacity .2s ease;
   -moz-transition: opacity .2s ease;
   z-index: 100;
+  width: 5px;
+  border-radius: 10%;
+  background-color: white;
 }
 .vjs-marker:hover {
   cursor: pointer;


### PR DESCRIPTION
Removing this programatic application on in-line styles to the marker divs allows linked or page-level CSS styles to be applied by publishers.