### PR TITLE
VIDLA-3480 - Added logic to allow publishers to defined Ad Marker CSS styles

### DIFF
--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -28,10 +28,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var markersHandler = function (vjs, markerOptions) {
+var markersHandler = function (vjs, adMarkerStyle) {
 	var _vjs = vjs;
 	var _player = null;
-	var _markerOptions = markerOptions;
+	var _adMarkerStyle = adMarkerStyle;
 
 	// default setting
 	var defaultSetting = {
@@ -96,8 +96,8 @@ var markersHandler = function (vjs, markerOptions) {
 	        breakOverlay = null,
 	        overlayIndex = NULL_INDEX;
 
-	    if (_markerOptions && _markerOptions.markerStyle) {
-	    	setting.markerStyle  = _vjs.mergeOptions(setting.markerStyle, _markerOptions.markerStyle);
+	    if (_adMarkerStyle) {
+	    	setting.markerStyle = _vjs.mergeOptions(setting.markerStyle, _adMarkerStyle);
 		}
 
 		function sortMarkersList() {

--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -96,6 +96,8 @@ var markersHandler = function (vjs, adMarkerStyle) {
 	        breakOverlay = null,
 	        overlayIndex = NULL_INDEX;
 
+	    // If an adMarkerStyle object was defined by the publisher in their options, merge that object into setting.markerStyle
+		// (Any style the publisher passed in will override the internal hard-coded defaults.)
 	    if (_adMarkerStyle) {
 	    	setting.markerStyle = _vjs.mergeOptions(setting.markerStyle, _adMarkerStyle);
 		}

--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -28,9 +28,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var markersHandler = function (vjs) {
+var markersHandler = function (vjs, markerOptions) {
 	var _vjs = vjs;
 	var _player = null;
+	var _markerOptions = markerOptions;
 
 	// default setting
 	var defaultSetting = {
@@ -90,12 +91,16 @@ var markersHandler = function (vjs) {
 	        markersMap = {},
 	        markersList = [],
 	        // list of markers sorted by time
-	    		currentMarkerIndex = NULL_INDEX,
+			currentMarkerIndex = NULL_INDEX,
 	        markerTip = null,
 	        breakOverlay = null,
 	        overlayIndex = NULL_INDEX;
 
-	    function sortMarkersList() {
+	    if (_markerOptions && _markerOptions.markerStyle) {
+	    	setting.markerStyle  = _vjs.mergeOptions(setting.markerStyle, _markerOptions.markerStyle);
+		}
+
+		function sortMarkersList() {
 	      // sort the list by time in asc order
 	      markersList.sort(function (a, b) {
 	        return setting.markerTip.time(a) - setting.markerTip.time(b);

--- a/src/VastManager.js
+++ b/src/VastManager.js
@@ -569,7 +569,7 @@ var vastManager = function () {
 			};
 			var needRegMarkers = false;
 			if (!_markersHandler) {
-				_markersHandler = new _MarkersHandler(videojs, _options.adMarkers);
+				_markersHandler = new _MarkersHandler(videojs, _options.adMarkerStyle);
 				needRegMarkers = true;
 			}
 			var seconds = convertStringToSeconds(_options.timeOffset, function(seconds) {

--- a/src/VastManager.js
+++ b/src/VastManager.js
@@ -569,7 +569,7 @@ var vastManager = function () {
 			};
 			var needRegMarkers = false;
 			if (!_markersHandler) {
-				_markersHandler = new _MarkersHandler(videojs);
+				_markersHandler = new _MarkersHandler(videojs, _options.adMarkers);
 				needRegMarkers = true;
 			}
 			var seconds = convertStringToSeconds(_options.timeOffset, function(seconds) {

--- a/tests/e2e/testPages/default-options.js
+++ b/tests/e2e/testPages/default-options.js
@@ -126,7 +126,12 @@ var defaultOptions = {
   	"adStartTimeout" : 3000,
   	"adServerTimeout" : 1000,
   	"timeOffset": "start",
-  	"adText": "Ad"
+  	"adText": "Ad",
+    "adMarkerStyle": {
+		"width": "5px",
+        "border-radius": "10%",
+        "background-color": "white"
+	}
 };
 
 function getOptions(cacheName) {


### PR DESCRIPTION
These changes give publishers a way to style ad markers  on the options config object via options.adMarkers.markerStyle