### PR TITLE
VIDLA-4340-4341

### DIFF
--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -453,6 +453,9 @@ function regPrebidVastPlugin(vjs) {
 			if (_vastManagerObj) {
 				_vastManagerObj.stop();
 			}
+			else if (_adListManagerObj) {
+				_adListManagerObj.stop();
+			}
 		}
 	});
 }

--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -325,7 +325,7 @@ var markersHandler = function (vjs, adMarkerStyle) {
 				var nextMarkerTime;
 
 				// post-roll support
-				if (currentTime === player.duration()) {
+				if (Math.abs(player.duration() - currentTime) < 0.1) {
 					if (setting.markerTip.time(markersList[markersList.length - 1]) === _videoDuration) {
 						if (options.onMarkerReached) {
 							options.onMarkerReached(markersList[markersList.length - 1]);


### PR DESCRIPTION
Fix for:
1. VIDLA-4340 (Stop Ad button on test pages do not work)
2. VIDLA-4341 (Safari browser - Postroll ad at "timeOffset": "100%" or "timeOffset": "end" does not play post-roll)