### PR TITLE
VIDLA-4193 - Fixed bug which blocked video title from appearing in player overlay

### DIFF
--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -387,8 +387,12 @@ var markersHandler = function (vjs, adMarkerStyle) {
 	      }
 	      onTimeUpdate();
 	      player.on('timeupdate', onTimeUpdate);
-	      player.off('loadedmetadata');
+	      player.off('loadedmetadata', onLoadedMetadata);
 	    }
+
+	    function onLoadedMetadata () {
+	    	initialize();
+		}
 
 	    if (setting.metadataLoaded || player.duration() > 0) {
 	    	setTimeout(function() {
@@ -397,9 +401,7 @@ var markersHandler = function (vjs, adMarkerStyle) {
 	    }
 	    else {
 		    // setup the plugin after we loaded video's meta data
-		    player.on('loadedmetadata', function () {
-		      initialize();
-		    });
+		    player.one('loadedmetadata', onLoadedMetadata);
 	    }
 
 	    // exposed plugin API

--- a/src/MarkersHandler.js
+++ b/src/MarkersHandler.js
@@ -387,10 +387,10 @@ var markersHandler = function (vjs, adMarkerStyle) {
 	      }
 	      onTimeUpdate();
 	      player.on('timeupdate', onTimeUpdate);
-	      player.off('loadedmetadata', onLoadedMetadata);
+	      player.off('loadedmetadata', loadedMetadataHandler);
 	    }
 
-	    function onLoadedMetadata () {
+	    function loadedMetadataHandler () {
 	    	initialize();
 		}
 
@@ -401,7 +401,7 @@ var markersHandler = function (vjs, adMarkerStyle) {
 	    }
 	    else {
 		    // setup the plugin after we loaded video's meta data
-		    player.one('loadedmetadata', onLoadedMetadata);
+		    player.one('loadedmetadata', loadedMetadataHandler);
 	    }
 
 	    // exposed plugin API


### PR DESCRIPTION
The MarkersHandler module had an erroneous event handler removal error that removed ALL player "loadedmetadata" listeners, causing tricky intermittent problems for displaying the title, and possibly elsewhere.