### PR TITLE
VIDLA-4212-4353

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     "one-var": "off",
     "no-extra-boolean-cast": "off",
     "new-cap": "off",
-    "handle-callback-err": 'off'
+    "handle-callback-err": 'off',
+    "no-extend-native": "off"
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "videoads-product-prebid-plugin",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Header Bidding plug-in for Brightcove player.",
 	"main": "src/BcPrebidVast.js",
 	"scripts": {

--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -19,7 +19,7 @@ var MOL_PLUGIN_URL = '//acdn.adnxs.com/video/plugins/mol/videojs_5.vast.vpaid.mi
 
 var $$PREBID_GLOBAL$$ = _prebidGlobal.getGlobal();
 
-_logger.always(_prefix, 'Version 0.3.3');
+_logger.always(_prefix, 'Version 0.3.4');
 
 var BC_prebid_in_progress = $$PREBID_GLOBAL$$.plugin_prebid_options && $$PREBID_GLOBAL$$.plugin_prebid_options.biddersSpec;
 

--- a/src/VastManager.js
+++ b/src/VastManager.js
@@ -269,6 +269,15 @@ var vastManager = function () {
 	function eventCallback(event) {
 		var arrResetEvents = ['vast.adError', 'vast.adsCancel', 'vast.adSkip', 'vast.reset',
 							  'vast.contentEnd', 'adFinished'];
+		var isResetEvent = function(name) {
+			for (var i = 0; i < arrResetEvents.length; i++) {
+				if (arrResetEvents[i] === name) {
+					return true;
+				}
+			}
+			return false;
+		};
+
 		var name = event.type;
 		if (name === 'vast.adStart') {
 			_adIndicator.style.display = 'block';
@@ -281,7 +290,7 @@ var vastManager = function () {
 		else if (name === 'trace.event') {
 			traceEvent(event);
 		}
-		else if (arrResetEvents.includes(name)) {
+		else if (isResetEvent(name)) {
 			resetContent();
 		}
 		else if (name === 'internal') {


### PR DESCRIPTION
Fixes for:
1. VIDLA-4212 (Two Playlist pages freeze with black screen on IE 11 browser)
2. VIDLA-4353 (PC IE11 - Ad does not play; Object doesn't support property or method 'find' error is thrown)