### PR TITLE
VIDLA-4477

### DIFF
--- a/src/AdListManager.js
+++ b/src/AdListManager.js
@@ -321,6 +321,9 @@ var adListManager = function () {
 			if (internalName === 'cover') {
 				showCover(event.data.cover);
 			}
+			else if (internalName === 'resetContent') {
+				resetContent();
+			}
 		}
 	}
 

--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -512,7 +512,9 @@ function loadMolPlugin(callback) {
 		_molIFrame = frame;
 
         try {
-            writeAsyncScriptToFrame(frame, MOL_PLUGIN_URL, true, getOrigin());
+			// make sure for every new plugin version we reload MOL plugin
+			var molPath = MOL_PLUGIN_URL + '?rand=' + PLUGIN_VERSION;
+            writeAsyncScriptToFrame(frame, molPath, true, getOrigin());
 
             frame.contentWindow.addEventListener('message', onLoadIFrame);
         }

--- a/src/VastManager.js
+++ b/src/VastManager.js
@@ -298,6 +298,9 @@ var vastManager = function () {
 			if (internalName === 'cover') {
 				showCover(event.data.cover);
 			}
+			else if (internalName === 'resetContent') {
+				resetContent();
+			}
 		}
 	}
 

--- a/src/VastRenderer.js
+++ b/src/VastRenderer.js
@@ -100,6 +100,14 @@ var vastRenderer = function (player) {
 
     // play single ad
     this.playAd = function(xml, options, firstVideoPreroll, mobilePrerollNeedClick, prerollNeedClickToPlay, eventCallback) {
+        // if MOL plugin is not registered in videojs immediatelly notify caller and return
+        if (!_player.vastClient || typeof _player.vastClient != 'function') {
+            if (eventCallback) {
+                eventCallback({type: 'internal', data: {name: 'resetContent'}});
+            }
+            return;
+        }
+
         _eventCallback = eventCallback;
         _options = options;
 


### PR DESCRIPTION
Fix for VIDLA-4477 (Chrome MAC - cached MOL plugin creates uncaught exception when it should fail gracefully)