### PR TITLE
VIDLA-4591 Fixes Brightcove 5.28.1 player double-tap bug on iPad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "videoads-product-prebid-plugin",
-	"version": "0.4.7",
+	"version": "0.4.8",
 	"loaderVersion": "0.4.5",
 	"description": "Header Bidding plug-in for Brightcove player.",
 	"main": "src/BcPrebidVast.js",

--- a/src/AdListManager.js
+++ b/src/AdListManager.js
@@ -329,7 +329,7 @@ var adListManager = function () {
 	}
 
 	// function to play vast xml
-	var playAd = function(adData) {
+	var playAd = function(adData, forseAdToAutoplay) {
 		if (_adPlaying) {
 			// not interrupt playing ad
 			showCover(false);
@@ -358,6 +358,9 @@ var adListManager = function () {
 		adData.status = AD_STATUS_PLAYING;
 		_firstAd = false;
 		_adTime = adData.adTime;
+		if (forseAdToAutoplay) {
+			_options.initialPlayback = 'auto';
+		}
 		_vastRendererObj.playAd(adData.adTag, _options, firstVideoPreroll, _mobilePrerollNeedClick, _prerollNeedClickToPlay, eventCallback);
 	};
 
@@ -437,7 +440,8 @@ var adListManager = function () {
 									_mobilePrerollNeedClick = false;	// don't need more click for preroll on iPad
 									showCover(true);
 									adData.status = AD_STATUS_PLAYING;
-									playAd(adData);
+									// make sure ad going to autoplay
+									playAd(adData, true);
 								});
 							}
 							else {

--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -11,7 +11,7 @@ var _adListManager = require('./AdListManager.js');
 var _prebidCommunicator = require('./PrebidCommunicator.js');
 var _logger = require('./Logging.js');
 
-var PLUGIN_VERSION = '0.4.7';
+var PLUGIN_VERSION = '0.4.8';
 var _prefix = 'PrebidVast->';
 var _molIFrame = null;
 

--- a/src/VastRenderer.js
+++ b/src/VastRenderer.js
@@ -23,7 +23,7 @@ var vastRenderer = function (player) {
 	// set ad playback options base on main content state
 	function setPlaybackMethodData() {
 		var initPlayback = 'auto';
-    	if (_player.currentTime() === 0) {
+    	if (_player.currentTime() === 0 && !_options.initialPlayback) {
             initPlayback = _player.autoplay() ? 'auto' : 'click';
     	}
 		var initAudio = _player.muted() ? 'off' : 'on';


### PR DESCRIPTION
In BC 5.28.1 players, a double-tap was required to start the ad/video on iPad. This fixes that bug. Submitting PR for @ynisman's branch while he is out of the office.