### PR TITLE
VIDLA-4717 - Added polyfill for Object.assign() to support IE in DfpUrlGenerator.js

### DIFF
--- a/src/DfpUrlGenerator.js
+++ b/src/DfpUrlGenerator.js
@@ -1,4 +1,39 @@
 /**
+ * Polyfill for Object.assign() - used by this code but not supported in IE.
+ * Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+ */
+
+if (typeof Object.assign !== 'function') {
+	// Must be writable: true, enumerable: false, configurable: true
+	Object.defineProperty(Object, 'assign', {
+		value: function assign(target, varArgs) { // .length of function is 2
+			'use strict';
+			if (target == null) { // TypeError if undefined or null
+				throw new TypeError('Cannot convert undefined or null to object');
+			}
+
+			var to = Object(target);
+
+			for (var index = 1; index < arguments.length; index++) {
+				var nextSource = arguments[index];
+
+				if (nextSource != null) { // Skip over if undefined or null
+					for (var nextKey in nextSource) {
+						// Avoid bugs when hasOwnProperty is shadowed
+						if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+							to[nextKey] = nextSource[nextKey];
+						}
+					}
+				}
+			}
+			return to;
+		},
+		writable: true,
+		configurable: true
+	});
+}
+
+/**
  * DFP Url Generator module.
  * @module DfpUrlGenerator
  */


### PR DESCRIPTION
IE doesn't support Object.assign() so we needed to add a polyfill