### PR TITLE
VSSPP-442

### DIFF
--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -652,7 +652,7 @@ function loadImaPlugin (callback) {
 
 	// validation for header bidding
 	if (!_player) {
-        _logger.warn(_prefix, 'Can\'t load IMA Plugin now - Brightcove player isn\'t loaded yet. We need player for auto-registration IMA plugin.');
+        _logger.warn(_prefix, 'Can\'t load IMA Plugin now - Brightcove player isn\'t loaded yet. The player must be loaded for auto-registration of the IMA plugin. Will attempt to load the IMA Plugin later.');
         callback(false);
         return;
 	}

--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -650,6 +650,13 @@ function loadImaPlugin (callback) {
         return;
 	}
 
+	// validation for header bidding
+	if (!_player) {
+        _logger.warn(_prefix, 'Can\'t load IMA Plugin now - Brightcove player isn\'t loaded yet. We need player for auto-registration IMA plugin.');
+        callback(false);
+        return;
+	}
+
     if (!_imaTriedToLoad) {
 		// check if IMA plugin is imbedded in player
 		if (_player.ima3) {


### PR DESCRIPTION
Fix for VSSPP-442 (Prebid header - When using dfp, Uncaught TypeError: Cannot read property 'ima3' of undefined is thrown)