### PR TITLE
updating preprocessor-loader dev dependancy, fixes npm install step.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"karma-webpack": "^2.0.4",
 		"mocha": "^3.2.0",
 		"node-sass": "^3.2.0",
-		"preprocessor-loader": "^0.0.8",
+		"preprocessor-loader": "^1.0.0",
 		"raw-loader": "^0.5.1",
 		"requirejs": "^2.3.3",
 		"sass-loader": "^2.0.1",


### PR DESCRIPTION
for a couple of versions of node (I started with v11.6.0), I simply tried running `npm i` and it failed, throwing an error, the problem was with something in `preprocessor-loader` so I updated that dependancy and tried again, which then worked for me.