### PR TITLE
Fix for VSSPP-553

### DIFF
--- a/src/VastRenderer.js
+++ b/src/VastRenderer.js
@@ -48,6 +48,9 @@ var vastRenderer = function (player) {
 	// show/hide brightcove controls activated for next clip within playlist
 	var showNextOverlay = function showNextOverlay (show) {
 		var nextOverlays = document.getElementsByClassName('vjs-next-overlay');
+		if (!nextOverlays || nextOverlays.length === 0) {
+			nextOverlays = document.getElementsByClassName('vjs-next-button');
+		}
 		if (nextOverlays && nextOverlays.length > 0) {
 			nextOverlays[0].style.display = show ? '' : 'none';
 		}


### PR DESCRIPTION
Fix for VSSPP-553 (MOL renderer - Playlist pages - content video forward button is visible and functional during Ad)