### PR TITLE
Fix for VSSPP-1140

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "videoads-product-prebid-plugin",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"loaderVersion": "0.4.6",
 	"description": "Header Bidding plug-in for Brightcove player.",
 	"main": "src/BcPrebidVast.js",

--- a/src/AdListManager.js
+++ b/src/AdListManager.js
@@ -962,6 +962,10 @@ var adListManager = function () {
 			_player.el().appendChild(_spinnerDiv);
 		}
 		_hasPreroll = optionsHavePreroll();
+		// force playsinline for preroll on iPhone when player configured for autoplay-muted
+		if (_hasPreroll && isIPhone() && _player.autoplay() === 'muted') {
+			_player.playsinline(true);
+		}
 		showCover(_hasPreroll);
 
 		_player.on('playlistitem', nextListItemHandlerAuto);

--- a/src/BcPrebidVast.js
+++ b/src/BcPrebidVast.js
@@ -13,7 +13,7 @@ var _dfpUrlGenerator = require('./DfpUrlGenerator.js');
 var _adapterManager = require('./AdapterManager.js');
 var _logger = require('./Logging.js');
 
-var PLUGIN_VERSION = '0.7.3';
+var PLUGIN_VERSION = '0.7.4';
 var _prefix = 'PrebidVast->';
 var _molIFrame = null;
 


### PR DESCRIPTION
Fix for VSSPP-1140 (IOS (iPhone) - IMA playlist page - Ad and content video never load (black screen with spinner present) - REGRESSION)