### PR TITLE
Fix for Github issue 154

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "videoads-product-prebid-plugin",
 	"version": "0.7.4",
-	"loaderVersion": "0.4.6",
+	"loaderVersion": "0.4.7",
 	"description": "Header Bidding plug-in for Brightcove player.",
 	"main": "src/BcPrebidVast.js",
 	"scripts": {

--- a/src/BcPrebidLoader.js
+++ b/src/BcPrebidLoader.js
@@ -8,7 +8,7 @@ var _prebidGlobal = require('./PrebidGlobal.js');
 var _logger = require('./Logging.js');
 
 // CONSTANTS
-var LOADER_VERSION = '0.4.6';
+var LOADER_VERSION = '0.4.7';
 var PREBID_PLUGIN_ID = 'bcPrebidVastPlugin';
 var COMMAND_PLUGIN_ID = 'bcPrebidVastPluginCommand';
 var DEFAULT_PLUGIN_JS_URL = '//acdn.adnxs.com/video/plugins/bc/prebid/bc_prebid_vast_plugin.min.js';
@@ -200,7 +200,9 @@ function apiInit () {
     		cover.style.height = '100%';
     		cover.style.backgroundColor = 'black';
     		cover.style.position = 'absolute';
-    		cover.style.zIndex = 101;
+			cover.style.zIndex = 101;
+			cover.style.left = '0px';
+			cover.style.top = '0px';
     		_player.el().appendChild(cover);
 		}
 


### PR DESCRIPTION
Fix for Github issue 154 (Main video content is sometimes visible before the preroll ad starts when the player is positioned differently on the page than in our test pages)

The black cover div was positioned incorrectly.